### PR TITLE
Use clap for command line argument parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ hex = "0.4"
 home = "0.5.4"
 clap = { version = "4.0.24", features = ["derive"] }
 sha2 = "0.10.6"
-sled = { version = "0.34", optional = true }
-redis = { version = "0.22.1", features = ["tokio-comp"], optional = true }
+sled = { version = "0.34" }
+redis = { version = "0.22.1", features = ["tokio-comp"] }
 axum = "0.5.17"
 dioxus = { version = "0.2.4", features = ["ssr"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ tonic_openssl_lnd = "0.2.0"
 tokio = "1"
 tokio-stream = "0.1.11"
 hex = "0.4"
+home = "0.5.4"
+clap = { version = "4.0.24", features = ["derive"] }
 sha2 = "0.10.6"
 sled = { version = "0.34", optional = true }
 redis = { version = "0.22.1", features = ["tokio-comp"], optional = true }

--- a/README.md
+++ b/README.md
@@ -16,15 +16,20 @@ cargo run -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_T
 
 With sled db:
 ```
-cargo run --features sled -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
+cargo run-- --database sled --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
+```
+
+With sled db with custom path:
+```
+cargo run-- --db-path {DB_PATH} --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
 ```
 
 With redis db with localhost:
 ```
-cargo run --features redis -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
+cargo run -- --database redis --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
 ```
 
 With redis db with specified url:
 ```
-cargo run --features redis -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON} --redis-url {REDIS_URL}
+cargo run -- --redis-url {REDIS_URL} --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # preimage-stealer
 
-A utility to connect to claim HTLCs that we have already seen the preimage for.
+A utility to automatically claim HTLCs with revealed preimages.
 This will automatically execute things like wormhole attacks for the user, allowing them to get free bitcoin.
 
 Currently, this works by connecting to a lnd node and subscribes to the HTLC events to get preimages to save and the
@@ -11,20 +11,20 @@ HTLC interceptor to execute the theft.
 In memory storage:
 
 ```
-cargo run {LND_HOST} {LND_GRPC_PORT} {PATH_TO_LND_TLS_CERT} {PATH_TO_LND_ADMIN_MACAROON}
+cargo run -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
 ```
 
 With sled db:
 ```
-cargo run --features sled {LND_HOST} {LND_GRPC_PORT} {PATH_TO_LND_TLS_CERT} {PATH_TO_LND_ADMIN_MACAROON}
+cargo run --features sled -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
 ```
 
 With redis db with localhost:
 ```
-cargo run --features redis {LND_HOST} {LND_GRPC_PORT} {PATH_TO_LND_TLS_CERT} {PATH_TO_LND_ADMIN_MACAROON}
+cargo run --features redis -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON}
 ```
 
 With redis db with specified url:
 ```
-cargo run --features redis {LND_HOST} {LND_GRPC_PORT} {PATH_TO_LND_TLS_CERT} {PATH_TO_LND_ADMIN_MACAROON} {REDIS_URL}
+cargo run --features redis -- --host {LND_HOST} --port {LND_GRPC_PORT} --cert-file {PATH_TO_LND_TLS_CERT} --macaroon-file {PATH_TO_LND_ADMIN_MACAROON} --redis-url {REDIS_URL}
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,54 @@
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, author)]
+/// A utility to automatically claim HTLCs with revealed preimages
+pub struct Config {
+    #[clap(default_value_t = String::from("127.0.0.1"), long)]
+    /// Host of the GRPC server for lnd
+    pub host: String,
+    #[clap(default_value_t = 10009, short, long)]
+    /// Port of the GRPC server for lnd
+    pub port: u32,
+    #[clap(default_value_t = String::from("mainnet"), short, long)]
+    /// Network lnd is running on ["mainnet", "testnet", "signet, "simnet, "regtest"]
+    pub network: String,
+    #[clap(long)]
+    /// Path to tls.cert file for lnd
+    pub cert_file: Option<String>,
+    #[clap(long)]
+    /// Path to admin.macaroon file for lnd
+    pub macaroon_file: Option<String>,
+    #[cfg(feature = "sled")]
+    #[clap(long, short)]
+    /// Sled database path
+    pub db_path: Option<String>,
+    #[cfg(feature = "redis")]
+    #[clap(long)]
+    /// Redis server url
+    pub redis_url: Option<String>,
+}
+
+fn home_dir() -> String {
+    let buf = home::home_dir().expect("Failed to get home directory");
+    let str = format!("{}", buf.display());
+
+    // to be safe remove possible trailing '/' and
+    // we can manually add it to paths
+    match str.strip_suffix('/') {
+        Some(stripped) => stripped.to_string(),
+        None => str,
+    }
+}
+
+pub fn default_cert_file() -> String {
+    format!("{}/.lnd/tls.cert", home_dir())
+}
+
+pub fn default_macaroon_file(network: String) -> String {
+    format!(
+        "{}/.lnd/data/chain/bitcoin/{}/admin.macaroon",
+        home_dir(),
+        network
+    )
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,11 +19,12 @@ pub struct Config {
     #[clap(long)]
     /// Path to admin.macaroon file for lnd
     pub macaroon_file: Option<String>,
-    #[cfg(feature = "sled")]
-    #[clap(long, short)]
+    #[clap(short, long)]
+    /// Type of database ["memory", "sled", "redis"] [default: memory]
+    pub database: Option<String>,
+    #[clap(long)]
     /// Sled database path
     pub db_path: Option<String>,
-    #[cfg(feature = "redis")]
     #[clap(long)]
     /// Redis server url
     pub redis_url: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // This program accepts four arguments: host, port, cert file, macaroon file
 
+mod config;
 mod memory;
 #[cfg(feature = "redis")]
 mod redis;
@@ -11,6 +12,7 @@ mod subscribers;
 use axum::response::Html;
 use axum::routing::get;
 use axum::{Extension, Router};
+use clap::Parser;
 use dioxus::prelude::*;
 use std::sync::Arc;
 
@@ -20,6 +22,7 @@ use crate::redis::RedisStorage;
 #[cfg(feature = "sled")]
 use crate::sled::SledStorage;
 
+use crate::config::*;
 use crate::storage::Storage;
 use crate::subscribers::*;
 use tokio::sync::Mutex;
@@ -27,36 +30,21 @@ use tokio::task::spawn;
 
 #[tokio::main]
 async fn main() {
-    let mut args = std::env::args_os();
-    args.next().expect("not even zeroth arg given");
-    let host = args
-        .next()
-        .expect("missing arguments: host, port, cert file, macaroon file");
-    let port = args
-        .next()
-        .expect("missing arguments: port, cert file, macaroon file");
-    let cert_file = args
-        .next()
-        .expect("missing arguments: cert file, macaroon file");
-    let macaroon_file = args.next().expect("missing argument: macaroon file");
-    let host: String = host.into_string().expect("host is not UTF-8");
-    let port: u32 = port
-        .into_string()
-        .expect("port is not UTF-8")
-        .parse()
-        .expect("port is not u32");
-    let cert_file: String = cert_file.into_string().expect("cert_file is not UTF-8");
-    let macaroon_file: String = macaroon_file
-        .into_string()
-        .expect("macaroon_file is not UTF-8");
+    let config: Config = Config::parse();
+    let config_clone = config.clone();
+
+    let cert_file = config.cert_file.unwrap_or_else(|| default_cert_file());
+    let macaroon_file = config
+        .macaroon_file
+        .unwrap_or_else(|| default_macaroon_file(config.network));
 
     // Connecting to LND requires only host, port, cert file, macaroon file
-    let mut client = tonic_openssl_lnd::connect(host, port, cert_file, macaroon_file)
+    let mut client = tonic_openssl_lnd::connect(config.host, config.port, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
     let client_router = client.router().clone();
 
-    let storage = load_storage(args);
+    let storage = load_storage(config_clone);
 
     // HTLC event stream part
     println!("starting htlc event subscription");
@@ -95,40 +83,34 @@ async fn main() {
         .unwrap();
 }
 
-// name this _args to keep clippy happy when it's unused
 #[allow(unreachable_code)]
 #[allow(dead_code)]
-fn load_storage(args: std::env::ArgsOs) -> Arc<Mutex<dyn Storage + Send>> {
+#[allow(unused)]
+fn load_storage(cfg: Config) -> Arc<Mutex<dyn Storage + Send>> {
     #[cfg(feature = "sled")]
     {
-        return Arc::new(Mutex::new(parse_sled_config(args)));
+        return Arc::new(Mutex::new(parse_sled_config(cfg)));
     }
     #[cfg(feature = "redis")]
     {
-        return Arc::new(Mutex::new(parse_redis_config(args)));
+        return Arc::new(Mutex::new(parse_redis_config(cfg)));
     }
 
     Arc::new(Mutex::new(MemoryStorage::new()))
 }
 
 #[cfg(feature = "sled")]
-fn parse_sled_config(mut args: std::env::ArgsOs) -> SledStorage {
-    match args.next() {
-        Some(arg) => {
-            let str = arg.into_string().expect("Failed to parse sled config arg");
-            SledStorage::new(str.as_str()).expect("Failed to create sled storage")
-        }
+fn parse_sled_config(cfg: Config) -> SledStorage {
+    match cfg.db_path {
+        Some(str) => SledStorage::new(str.as_str()).expect("Failed to create sled storage"),
         None => SledStorage::default(),
     }
 }
 
 #[cfg(feature = "redis")]
-fn parse_redis_config(mut args: std::env::ArgsOs) -> RedisStorage {
-    match args.next() {
-        Some(arg) => {
-            let str = arg.into_string().expect("Failed to parse redis config arg");
-            RedisStorage::new(str.as_str()).expect("Failed to create redis storage")
-        }
+fn parse_redis_config(cfg: Config) -> RedisStorage {
+    match cfg.redis_url {
+        Some(str) => RedisStorage::new(str.as_str()).expect("Failed to create redis storage"),
         None => RedisStorage::default(),
     }
 }


### PR DESCRIPTION
Using this library for command line parsing: https://docs.rs/clap/latest/clap/

Made it so we default to lnd's defaults if no arguments are passed and allow for much easier passing of the other arguments.

If we are going to do a real release it would probably make sense to remove the rust feature flags and just have those configurable.

Allows for nice help messages too:
![image](https://user-images.githubusercontent.com/112777112/201884270-4be59423-0886-4435-ba93-5c0281467270.png)
